### PR TITLE
Fixed initialization problem for right channel

### DIFF
--- a/voclib.h
+++ b/voclib.h
@@ -487,6 +487,7 @@ void voclib_reset_history ( voclib_instance* instance )
         {
             voclib_BiQuad_reset ( &instance->analysis_bands[i].filters[i2] );
             voclib_BiQuad_reset ( &instance->synthesis_bands[i].filters[i2] );
+            voclib_BiQuad_reset ( &instance->synthesis_bands[i + VOCLIB_MAX_BANDS].filters[i2] );
         }
         voclib_envelope_reset ( &instance->analysis_envelopes[i] );
     }


### PR DESCRIPTION
Hi，there is a missing initialization for the right channel when the carrior is stereo.
It will sometimes cause NAN output in right channel. 