### PR TITLE
vocshell: fix memory leak in write_wave_file()

### DIFF
--- a/shell/vocshell.c
+++ b/shell/vocshell.c
@@ -41,17 +41,19 @@ int write_wave_file ( const char* filename, unsigned int sample_rate, unsigned i
     outfile = drwav_open_file_write_sequential ( filename, &format, frames * channels );
     if ( outfile == NULL )
     {
+        free(converted);
         return 0;
     }
 
     if ( drwav_write ( outfile, frames * channels, &converted[0] ) != frames * channels )
     {
         drwav_close ( outfile );
+        free(converted);
         return 0;
     }
 
     drwav_close ( outfile );
-
+    free(converted);
     return 1;
 }
 


### PR DESCRIPTION
Signed-off-by: Stephen M. Cameron <stephenmcameron@gmail.com>